### PR TITLE
Fix error in logout function

### DIFF
--- a/PrestashopBridge.php
+++ b/PrestashopBridge.php
@@ -125,7 +125,7 @@ class PrestashopBridge {
 	public function logout() {
 
 		$ctx = \Context::getContext();
-		if (!$ctx)
+		if ($ctx)
 			$ctx->customer->logout();
 	}
 


### PR DESCRIPTION
Logout customer if context exists, not the contrary
